### PR TITLE
Connection Problem gelöst, FTP-Port wird von Docker vergeben

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,10 +76,19 @@ services:
 
   ftpd_server:
     image: stilliard/pure-ftpd:hardened
-    container_name: pure-ftpd
+    container_name: osmp4j-ftpd
     ports:
-      - 21:21
-      - 30000-30009:30000-30009
+      - 21
+      - 30000:30000
+      - 30001:30001
+      - 30002:30002
+      - 30003:30003
+      - 30004:30004
+      - 30005:30005
+      - 30006:30006
+      - 30007:30007
+      - 30008:30008
+      - 30009:30009
     environment:
       PUBLICHOST: "localhost"
       FTP_USER_NAME: osmp4jadmin


### PR DESCRIPTION
**Fix für FTPConnection Probleme.**

_**Problem:**
Port 21 kann auf unseren Hosts nicht verwendet werden.
Port zu einem anderen ändern (30021:21) funktioniert nicht, da Docker dann aus ungeklärten Gründen einen Fehler schmeißt._

_**Lösung:**
Port in Docker Compose zwar exposen, jedoch nicht zuweisen. Port wird dann von Docker zugewiesen.
Zum Connecten von unseren Hosts, kann der Port aus Docker ausgelesen werden._ 